### PR TITLE
fixed bug where cb() needs to be called with a 'null' parameter

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -24,7 +24,7 @@ function _getFile(body, cb) {
 		data = JSON.parse(body);
 	} catch (e) {
 		require('fs').writeFileSync(__dirname + '/problem.json', body);
-		cb('Cannot parse JSON file.');
+		cb('Cannot parse JSON file.', null);
 		return;
 	}
 	cb(null, data);


### PR DESCRIPTION
minor fix to actually catch the case if a download couldn't be processed. Now a proper error is returned.